### PR TITLE
Docker/Podman volume mount option to relabel in case of selinux & fixed path

### DIFF
--- a/docs/guide/iso-build/how-to-build.md
+++ b/docs/guide/iso-build/how-to-build.md
@@ -15,7 +15,7 @@ If you want to build the build container yourself [link](#build-your-own-contain
 ### Docker plain
 
 1. Have a workdirectory with your [`config/`](./config) adjusted for your client
-2. Run `docker run -it -v $(pwd)/config:/config -v $(pwd)/output:/output ghcr.io/projectpotos/potos-iso-builder:latest`
+2. Run `docker run -it -v $(pwd)/config:/config:Z -v $(pwd)/output:/output:Z ghcr.io/projectpotos/potos-iso-builder:latest`
 3. Enjoy the iso in `output/`
 
 ### Docker compose

--- a/docs/guide/iso-build/how-to-build.md
+++ b/docs/guide/iso-build/how-to-build.md
@@ -45,7 +45,7 @@ jobs:
         with:
           image: ghcr.io/projectpotos/potos-iso-builder:latest
           run: ./build-iso
-          options: -v ${{ github.workspace }}:/config -v /output:/output
+          options: -v ${{ github.workspace }}/config:/config:Z -v /output:/output:Z
       - name: Save iso
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
## Description

I'm running podman/docker on a selinux enabled system. In that case you'll need to add an option to volume mounts for relabeling contexts.

Apart from that I fixed the path in the github workflow to mount the config directory as described.